### PR TITLE
feat: Add utilities for converting ZuCo 2.0 spectro EEG data from MATLAB …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dataset/*

--- a/util/construct_dataset_mat_to_pickle_v1_spectro.py
+++ b/util/construct_dataset_mat_to_pickle_v1_spectro.py
@@ -96,4 +96,3 @@ print('num of sent:', len(whole_dataset['ZAB']))
 print()
 print('max length:', max_len)
 
-

--- a/util/construct_dataset_mat_to_pickle_v2_spectro.py
+++ b/util/construct_dataset_mat_to_pickle_v2_spectro.py
@@ -7,20 +7,39 @@ from tqdm import tqdm
 import numpy as np
 import pickle
 import argparse
-import data_loading_helpers_modified as dh
 
-parser = argparse.ArgumentParser(description='Specify task name for converting ZuCo v1.0 Mat file to Pickle')
-parser.add_argument('-t', '--task_name',
-                    help='name of the task in /dataset/ZuCo, choose from {task1-SR,task2-NR,task3-TSR}', required=True)
+
+def read_hdf5_string(h5file, ref):
+    """Read a string from HDF5 reference (MATLAB stores as uint16 array)."""
+    data = h5file[ref][()]
+    if data.dtype == np.uint16:
+        return ''.join(chr(c) for c in data.flatten())
+    return str(data)
+
+
+def read_hdf5_array(h5file, ref):
+    """Read an array from HDF5 reference."""
+    data = h5file[ref][()]
+    # HDF5 stores data in column-major order, transpose for row-major
+    if isinstance(data, np.ndarray) and data.ndim == 2:
+        return data.T
+    return data
+
+
+def is_valid_ref(ref):
+    """Check if ref is a valid HDF5 object reference."""
+    return isinstance(ref, h5py.Reference)
+
+
+parser = argparse.ArgumentParser(description='Specify task name for converting ZuCo Mat file to Pickle (supports v7.3 HDF5 format)')
+parser.add_argument('-t', '--task_name', help='name of the task in /dataset/ZuCo, choose from {task1-SR,task2-NR,task3-TSR,task2-NR-2.0}', required=True)
 args = vars(parser.parse_args())
 
+
 """config"""
-version = 'v2' # 'new'
+version = 'v1' # 'old'
 
 task_name = args['task_name']
-# task_name = 'task1-SR'
-# task_name = 'task2-NR'
-# task_name = 'task3-TSR'
 
 
 print('##############################')
@@ -33,7 +52,7 @@ if not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
 """load files"""
-mat_files = glob(os.path.join(input_mat_files_dir, '*.mat'))
+mat_files = glob(os.path.join(input_mat_files_dir,'*.mat'))
 mat_files = sorted(mat_files)
 
 if len(mat_files) == 0:
@@ -43,56 +62,87 @@ if len(mat_files) == 0:
 dataset_dict = {}
 max_len = -1
 for mat_file in tqdm(mat_files):
-    subject_name = os.path.basename(mat_file).split('_')[0].replace('results', '').strip()
+    subject_name = os.path.basename(mat_file).split('_')[0].replace('results','').strip()
     dataset_dict[subject_name] = []
-    subject = mat_file.split("ts")[1].split("_")[0]
 
+    # Use h5py for MATLAB v7.3 files (HDF5 format)
+    with h5py.File(mat_file, 'r') as h5file:
+        sd = h5file['sentenceData']
+        
+        # ZuCo 2.0 structure: sentenceData is a Group with parallel arrays
+        # content, rawData, word are each (N, 1) arrays of HDF5 references
+        content_refs = sd['content'][()]
+        rawdata_refs = sd['rawData'][()]
+        word_refs = sd['word'][()]
+        
+        num_sentences = content_refs.shape[0]
+        
+        for i in range(num_sentences):
+            # Get references for this sentence (flatten from (N,1) to just the ref)
+            content_ref = content_refs[i, 0] if content_refs.ndim > 1 else content_refs[i]
+            rawdata_ref = rawdata_refs[i, 0] if rawdata_refs.ndim > 1 else rawdata_refs[i]
+            word_ref = word_refs[i, 0] if word_refs.ndim > 1 else word_refs[i]
+            
+            # Read content (sentence text)
+            try:
+                content = read_hdf5_string(h5file, content_ref)
+            except Exception as e:
+                print(f'Error reading content for sentence {i}: {e}')
+                dataset_dict[subject_name].append(None)
+                continue
+            
+            # Check word data - skip if not a valid reference
+            if not is_valid_ref(word_ref):
+                print(f'skipping sent (no word data): subj:{subject_name} content:{content[:50]}...')
+                dataset_dict[subject_name].append(None)
+                continue
+            
+            # Read rawData
+            try:
+                raw_data = read_hdf5_array(h5file, rawdata_ref)
+            except Exception as e:
+                print(f'missing rawData: subj:{subject_name} content:{content[:50]}..., error: {e}')
+                dataset_dict[subject_name].append(None)
+                continue
+            
+            # Check if rawData is valid (not NaN/empty)
+            if isinstance(raw_data, float) or (isinstance(raw_data, np.ndarray) and raw_data.size == 0):
+                print(f'missing sent: subj:{subject_name} content:{content[:50]}..., return None')
+                dataset_dict[subject_name].append(None)
+                continue
+            
+            # sentence level object
+            sent_obj = {'content': content}
+            sent_obj['sentence_level_EEG'] = {'rawData': raw_data}
+            
+            print(raw_data.shape)
+            
+            if raw_data.shape[1] > max_len:
+                max_len = raw_data.shape[1]
+            
+            if raw_data.shape[1] > 23631:
+                print(f'too long sent: subj:{subject_name} content:{content[:50]}..., return None')
+                dataset_dict[subject_name].append(None)
+                continue
+            
+            dataset_dict[subject_name].append(sent_obj)
 
-    f = h5py.File(mat_file, 'r')
-    sentence_data = f['sentenceData']
-    rawData = sentence_data['rawData']
-    contentData = sentence_data['content']
-    wordData = sentence_data['word']
-    print(rawData)
-    for idx in range(len(rawData)):
-        # get sentence string
-        obj_reference_content = contentData[idx][0]
-        sent_string = dh.load_matlab_string(f[obj_reference_content])
-        obj_reference_rawData = rawData[idx][0]
-        t_array = f[obj_reference_rawData][:].T.astype(np.float32)
-        print(t_array.shape)
-        if t_array.shape[1] == 1:
-            print(f'missing sent: subj:{subject} content:{sent_string}, append None')
-            dataset_dict[subject].append(None)
-            continue
-        if t_array.shape[1] > max_len:
-            max_len = t_array.shape[1]
-        if t_array.shape[1] > 23631:
-            print(f'too long sent: subj:{subject_name} content:{sent_string}, return None')
-            dataset_dict[subject_name].append(None)
-            continue
-        sent_obj = {'content': sent_string}
-        sent_obj['sentence_level_EEG'] = {'rawData': t_array}
-        dataset_dict[subject_name].append(sent_obj)
-
-print(max_len)
 """output"""
 output_name = f'{task_name}-dataset-spectro.pickle'
-# with open(os.path.join(output_dir,'task1-SR-dataset.json'), 'w') as out:
-#     json.dump(dataset_dict,out,indent = 4)
 
-with open(os.path.join(output_dir, output_name), 'wb') as handle:
+with open(os.path.join(output_dir,output_name), 'wb') as handle:
     pickle.dump(dataset_dict, handle, protocol=pickle.HIGHEST_PROTOCOL)
-    print('write to:', os.path.join(output_dir, output_name))
+    print('write to:', os.path.join(output_dir,output_name))
+
 
 """sanity check"""
 # check dataset
-with open(os.path.join(output_dir, output_name), 'rb') as handle:
+with open(os.path.join(output_dir,output_name), 'rb') as handle:
     whole_dataset = pickle.load(handle)
 print('subjects:', whole_dataset.keys())
 
-print('num of sent:', len(whole_dataset['YAC']))
+# Get first subject name for sanity check
+first_subject = list(whole_dataset.keys())[0]
+print(f'num of sent for {first_subject}:', len(whole_dataset[first_subject]))
 print()
 print('max length:', max_len)
-
-

--- a/util/inspect_hdf5.py
+++ b/util/inspect_hdf5.py
@@ -1,0 +1,57 @@
+"""Quick script to inspect HDF5 structure of MATLAB v7.3 files - v2"""
+import h5py
+import glob
+import numpy as np
+
+# Find the first mat file
+files = glob.glob('./dataset/ZuCo/task2-NR-2.0/Matlab_files/*.mat')
+print('Found files:', len(files))
+
+if files:
+    f = h5py.File(files[0], 'r')
+    
+    sd = f['sentenceData']
+    print('\n=== sentenceData keys ===')
+    all_keys = list(sd.keys())
+    print('All keys:', all_keys)
+    
+    # Check content - this likely contains sentence text references
+    print('\n=== content ===')
+    content = sd['content']
+    print('Type:', type(content))
+    print('Shape:', content.shape if hasattr(content, 'shape') else 'N/A')
+    
+    # Try to read some values
+    if hasattr(content, 'shape'):
+        print('Dtype:', content.dtype)
+        print('First 3 refs:', content[:3])
+        
+        # Dereference to get actual content
+        for i in range(min(3, content.shape[0])):
+            ref = content[i, 0] if content.ndim > 1 else content[i]
+            try:
+                dereferenced = f[ref]
+                print(f'  Sentence {i}: type={type(dereferenced)}')
+                if hasattr(dereferenced, 'shape'):
+                    data = dereferenced[()]
+                    print(f'    shape={data.shape}, dtype={data.dtype}')
+                    if data.dtype == np.uint16:
+                        text = ''.join(chr(c) for c in data.flatten())
+                        print(f'    text: {text[:100]}...')
+            except Exception as e:
+                print(f'  Error accessing {i}: {e}')
+    
+    # Check for rawData
+    print('\n=== Looking for rawData or EEG data ===')
+    for key in ['rawData', 'mean_t1', 'mean_t2', 'word']:
+        if key in sd:
+            item = sd[key]
+            print(f'{key}: type={type(item)}, shape={item.shape if hasattr(item, "shape") else "N/A"}')
+    
+    # Check what's in word if it exists
+    if 'word' in sd:
+        print('\n=== word ===')
+        word = sd['word']
+        print('Shape:', word.shape)
+        
+    f.close()


### PR DESCRIPTION
### Changes
- **Switched to `h5py`** for reading MATLAB v7.3 HDF5 files
- **Adapted to ZuCo 2.0 flat structure**:
  - `sentenceData` is a Group containing parallel arrays (`content`, `rawData`, `word`)
  - Each array contains HDF5 object references that need to be dereferenced
- **Added helper functions**:
  - [read_hdf5_string()](cci:1://file:///c:/MSc%20Files/MSc%20Project/ForeverNightmare-Repo/EEG2Text/util/construct_dataset_mat_to_pickle_v2_spectro.py:11:0-16:20) - Decodes MATLAB strings stored as uint16 arrays
  - [read_hdf5_array()](cci:1://file:///c:/MSc%20Files/MSc%20Project/ForeverNightmare-Repo/EEG2Text/util/construct_dataset_mat_to_pickle_v2_spectro.py:19:0-25:15) - Reads and transposes arrays from column-major to row-major order
  - [is_valid_ref()](cci:1://file:///c:/MSc%20Files/MSc%20Project/ForeverNightmare-Repo/EEG2Text/util/construct_dataset_mat_to_pickle_v2_spectro.py:28:0-30:42) - Validates HDF5 object references
- **Added skip logic** for sentences without word data

### Files Changed
- [util/construct_dataset_mat_to_pickle_v2_spectro.py](cci:7://file:///c:/MSc%20Files/MSc%20Project/ForeverNightmare-Repo/EEG2Text/util/construct_dataset_mat_to_pickle_v2_spectro.py:0:0-0:0) - Updated for HDF5 support
- [util/inspect_hdf5.py](cci:7://file:///c:/MSc%20Files/MSc%20Project/ForeverNightmare-Repo/EEG2Text/util/inspect_hdf5.py:0:0-0:0) - Debug utility for inspecting HDF5 structure (can be removed)